### PR TITLE
fix: Streamlit 배포 환경에서 한글 폰트 깨짐 이슈 해결 (DejaVuSans fallback 적용)

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 from pages import visual, map_ui, mbti, specialty
 
-# ✅ 한글 폰트 설정
 def setup_fonts():
     system = platform.system()
     if system == "Windows":
@@ -22,13 +21,16 @@ def setup_fonts():
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
     else:
-        font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
+        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+        if not os.path.exists(font_path):
+            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
 
     if os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
     else:
-        print(f"⚠️ 폰트 경로가 존재하지 않음: {font_path}")
+        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/map_ui.py
+++ b/pages/map_ui.py
@@ -15,20 +15,22 @@ import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 
 def setup_fonts():
-    """운영체제별로 안전한 한글 폰트 설정"""
     system = platform.system()
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:  # Linux (Streamlit Cloud 포함)
-        font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    else:
+        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
+        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+        if not os.path.exists(font_path):
+            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
 
     if os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
     else:
-        print(f"⚠️ 폰트 파일이 존재하지 않음: {font_path}")
+        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/mbti.py
+++ b/pages/mbti.py
@@ -6,20 +6,22 @@ import platform
 
 
 def setup_fonts():
-    """운영체제별로 안전한 한글 폰트 설정"""
     system = platform.system()
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:  # Linux (ex: Streamlit Cloud)
-        font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    else:
+        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
+        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+        if not os.path.exists(font_path):
+            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
 
     if os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
     else:
-        print(f"⚠️ 폰트 파일을 찾을 수 없습니다: {font_path}")
+        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/specialty.py
+++ b/pages/specialty.py
@@ -83,20 +83,22 @@ STYLE = {
 # ─────────────────────────────────────────────────────
 
 def setup_fonts():
-    """운영체제별로 한글 폰트 안전하게 설정"""
     system = platform.system()
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:  # Linux (Streamlit Cloud 포함)
-        font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    else:
+        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
+        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+        if not os.path.exists(font_path):
+            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
 
     if os.path.exists(font_path):
-        font_prop = fm.FontProperties(fname=font_path)
-        plt.rcParams["font.family"] = font_prop.get_name()
+        prop = fm.FontProperties(fname=font_path)
+        plt.rc("font", family=prop.get_name())
     else:
-        print(f"⚠️ 경고: 지정된 폰트 경로 없음 → {font_path}")
+        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/visual.py
+++ b/pages/visual.py
@@ -12,14 +12,17 @@ def setup_fonts():
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:  # Linux (예: Streamlit Cloud)
-        font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    else:
+        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
+        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+        if not os.path.exists(font_path):
+            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
 
     if os.path.exists(font_path):
-        font_prop = fm.FontProperties(fname=font_path)
-        plt.rcParams["font.family"] = font_prop.get_name()
+        prop = fm.FontProperties(fname=font_path)
+        plt.rc("font", family=prop.get_name())
     else:
-        print(f"⚠️ 폰트 파일이 존재하지 않아 기본 폰트로 진행합니다: {font_path}")
+        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 


### PR DESCRIPTION
- setup_fonts() 함수 내 플랫폼별 폰트 경로 분기 처리
  - Windows: Malgun Gothic
  - macOS: AppleGothic
  - Linux (Streamlit Cloud): NanumGothic 또는 DejaVuSans
- 한글 깨짐 없이 그래프 정상 출력되도록 설정