### PR TITLE
fix: Streamlit Cloud 한글 폰트 깨짐 문제 해결을 위한 setup_fonts 리팩토링

### DIFF
--- a/apt-packages.txt
+++ b/apt-packages.txt
@@ -1,0 +1,1 @@
+fonts-nanum

--- a/main.py
+++ b/main.py
@@ -15,22 +15,32 @@ import matplotlib.font_manager as fm
 from pages import visual, map_ui, mbti, specialty
 
 def setup_fonts():
+    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
+    font_path = None
     system = platform.system()
+
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
     else:
-        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
-        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
-        if not os.path.exists(font_path):
-            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        # ✅ Linux (Streamlit Cloud 포함)
+        candidates = [
+            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        ]
+        for path in candidates:
+            if os.path.exists(path):
+                font_path = path
+                break
 
-    if os.path.exists(font_path):
+    if font_path and os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
+        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
     else:
-        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/map_ui.py
+++ b/pages/map_ui.py
@@ -15,22 +15,32 @@ import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 
 def setup_fonts():
+    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
+    font_path = None
     system = platform.system()
+
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
     else:
-        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
-        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
-        if not os.path.exists(font_path):
-            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        # ✅ Linux (Streamlit Cloud 포함)
+        candidates = [
+            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        ]
+        for path in candidates:
+            if os.path.exists(path):
+                font_path = path
+                break
 
-    if os.path.exists(font_path):
+    if font_path and os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
+        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
     else:
-        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/mbti.py
+++ b/pages/mbti.py
@@ -6,22 +6,32 @@ import platform
 
 
 def setup_fonts():
+    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
+    font_path = None
     system = platform.system()
+
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
     else:
-        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
-        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
-        if not os.path.exists(font_path):
-            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        # ✅ Linux (Streamlit Cloud 포함)
+        candidates = [
+            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        ]
+        for path in candidates:
+            if os.path.exists(path):
+                font_path = path
+                break
 
-    if os.path.exists(font_path):
+    if font_path and os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
+        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
     else:
-        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/specialty.py
+++ b/pages/specialty.py
@@ -83,22 +83,32 @@ STYLE = {
 # ─────────────────────────────────────────────────────
 
 def setup_fonts():
+    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
+    font_path = None
     system = platform.system()
+
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
     else:
-        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
-        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
-        if not os.path.exists(font_path):
-            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        # ✅ Linux (Streamlit Cloud 포함)
+        candidates = [
+            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        ]
+        for path in candidates:
+            if os.path.exists(path):
+                font_path = path
+                break
 
-    if os.path.exists(font_path):
+    if font_path and os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
+        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
     else:
-        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 

--- a/pages/visual.py
+++ b/pages/visual.py
@@ -7,22 +7,32 @@ import platform  # ✅ 추가
 import matplotlib.font_manager as fm
 
 def setup_fonts():
+    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
+    font_path = None
     system = platform.system()
+
     if system == "Windows":
         font_path = "C:\\Windows\\Fonts\\malgun.ttf"
     elif system == "Darwin":
         font_path = "/System/Library/Fonts/AppleGothic.ttf"
     else:
-        # ✅ Linux (Streamlit Cloud) 환경에는 NanumGothic 또는 DejaVuSans 사용
-        font_path = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
-        if not os.path.exists(font_path):
-            font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        # ✅ Linux (Streamlit Cloud 포함)
+        candidates = [
+            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        ]
+        for path in candidates:
+            if os.path.exists(path):
+                font_path = path
+                break
 
-    if os.path.exists(font_path):
+    if font_path and os.path.exists(font_path):
         prop = fm.FontProperties(fname=font_path)
         plt.rc("font", family=prop.get_name())
+        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
     else:
-        print("⚠️ 시스템 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
 
     plt.rcParams["axes.unicode_minus"] = False
 


### PR DESCRIPTION
refactor: 운영체제별 setup_fonts 함수 개선 및 NanumGothic fallback 추가

- Windows, macOS, Linux 환경별 폰트 경로 분기 처리
- NanumGothic → NotoSans → DejaVuSans 순으로 폰트 후보 설정
- Streamlit Cloud에서도 한글 그래프 문제 없이 표시되도록 대응