### PR TITLE
feat: NanumGothic.ttf 폰트 파일 프로젝트에 직접 포함하여 한글 깨짐 해결

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,35 +14,17 @@ import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 from pages import visual, map_ui, mbti, specialty
 
+# setup_fonts 함수 수정
 def setup_fonts():
-    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
-    font_path = None
-    system = platform.system()
-
-    if system == "Windows":
-        font_path = "C:\\Windows\\Fonts\\malgun.ttf"
-    elif system == "Darwin":
-        font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:
-        # ✅ Linux (Streamlit Cloud 포함)
-        candidates = [
-            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
-            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-        ]
-        for path in candidates:
-            if os.path.exists(path):
-                font_path = path
-                break
-
-    if font_path and os.path.exists(font_path):
-        prop = fm.FontProperties(fname=font_path)
+    local_font_path = os.path.join(os.path.dirname(__file__), "assets", "fonts", "NanumGothic.ttf")
+    if os.path.exists(local_font_path):
+        prop = fm.FontProperties(fname=local_font_path)
         plt.rc("font", family=prop.get_name())
-        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
+        plt.rcParams["axes.unicode_minus"] = False
+        print(f"✅ 로컬 NanumGothic 적용됨: {prop.get_name()}")
     else:
-        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("❌ 로컬 폰트 파일 없음. 시스템 폰트 사용 시도")
 
-    plt.rcParams["axes.unicode_minus"] = False
 
 # ✅ 사이드바 자체 숨기기 (Streamlit 기본 탐색 제거)
 st.markdown("""

--- a/pages/map_ui.py
+++ b/pages/map_ui.py
@@ -14,35 +14,16 @@ import platform
 import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 
+# setup_fonts 함수 수정
 def setup_fonts():
-    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
-    font_path = None
-    system = platform.system()
-
-    if system == "Windows":
-        font_path = "C:\\Windows\\Fonts\\malgun.ttf"
-    elif system == "Darwin":
-        font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:
-        # ✅ Linux (Streamlit Cloud 포함)
-        candidates = [
-            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
-            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-        ]
-        for path in candidates:
-            if os.path.exists(path):
-                font_path = path
-                break
-
-    if font_path and os.path.exists(font_path):
-        prop = fm.FontProperties(fname=font_path)
+    local_font_path = os.path.join(os.path.dirname(__file__), "assets", "fonts", "NanumGothic.ttf")
+    if os.path.exists(local_font_path):
+        prop = fm.FontProperties(fname=local_font_path)
         plt.rc("font", family=prop.get_name())
-        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
+        plt.rcParams["axes.unicode_minus"] = False
+        print(f"✅ 로컬 NanumGothic 적용됨: {prop.get_name()}")
     else:
-        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
-
-    plt.rcParams["axes.unicode_minus"] = False
+        print("❌ 로컬 폰트 파일 없음. 시스템 폰트 사용 시도")
 
 def run():
     setup_fonts()  # ✅ 한글 폰트 깨짐 방지

--- a/pages/mbti.py
+++ b/pages/mbti.py
@@ -5,35 +5,17 @@ import matplotlib.font_manager as fm
 import platform
 
 
+# setup_fonts 함수 수정
 def setup_fonts():
-    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
-    font_path = None
-    system = platform.system()
-
-    if system == "Windows":
-        font_path = "C:\\Windows\\Fonts\\malgun.ttf"
-    elif system == "Darwin":
-        font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:
-        # ✅ Linux (Streamlit Cloud 포함)
-        candidates = [
-            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
-            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-        ]
-        for path in candidates:
-            if os.path.exists(path):
-                font_path = path
-                break
-
-    if font_path and os.path.exists(font_path):
-        prop = fm.FontProperties(fname=font_path)
+    local_font_path = os.path.join(os.path.dirname(__file__), "assets", "fonts", "NanumGothic.ttf")
+    if os.path.exists(local_font_path):
+        prop = fm.FontProperties(fname=local_font_path)
         plt.rc("font", family=prop.get_name())
-        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
+        plt.rcParams["axes.unicode_minus"] = False
+        print(f"✅ 로컬 NanumGothic 적용됨: {prop.get_name()}")
     else:
-        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("❌ 로컬 폰트 파일 없음. 시스템 폰트 사용 시도")
 
-    plt.rcParams["axes.unicode_minus"] = False
 
 def inject_css():
     st.markdown(

--- a/pages/specialty.py
+++ b/pages/specialty.py
@@ -82,35 +82,17 @@ STYLE = {
 }
 # ─────────────────────────────────────────────────────
 
+# setup_fonts 함수 수정
 def setup_fonts():
-    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
-    font_path = None
-    system = platform.system()
-
-    if system == "Windows":
-        font_path = "C:\\Windows\\Fonts\\malgun.ttf"
-    elif system == "Darwin":
-        font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:
-        # ✅ Linux (Streamlit Cloud 포함)
-        candidates = [
-            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
-            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-        ]
-        for path in candidates:
-            if os.path.exists(path):
-                font_path = path
-                break
-
-    if font_path and os.path.exists(font_path):
-        prop = fm.FontProperties(fname=font_path)
+    local_font_path = os.path.join(os.path.dirname(__file__), "assets", "fonts", "NanumGothic.ttf")
+    if os.path.exists(local_font_path):
+        prop = fm.FontProperties(fname=local_font_path)
         plt.rc("font", family=prop.get_name())
-        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
+        plt.rcParams["axes.unicode_minus"] = False
+        print(f"✅ 로컬 NanumGothic 적용됨: {prop.get_name()}")
     else:
-        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("❌ 로컬 폰트 파일 없음. 시스템 폰트 사용 시도")
 
-    plt.rcParams["axes.unicode_minus"] = False
 
 
 @st.cache_data

--- a/pages/visual.py
+++ b/pages/visual.py
@@ -6,35 +6,17 @@ import os
 import platform  # ✅ 추가
 import matplotlib.font_manager as fm
 
+# setup_fonts 함수 수정
 def setup_fonts():
-    """운영체제별로 폰트를 안전하게 설정하고, 한글 깨짐 방지"""
-    font_path = None
-    system = platform.system()
-
-    if system == "Windows":
-        font_path = "C:\\Windows\\Fonts\\malgun.ttf"
-    elif system == "Darwin":
-        font_path = "/System/Library/Fonts/AppleGothic.ttf"
-    else:
-        # ✅ Linux (Streamlit Cloud 포함)
-        candidates = [
-            "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
-            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-        ]
-        for path in candidates:
-            if os.path.exists(path):
-                font_path = path
-                break
-
-    if font_path and os.path.exists(font_path):
-        prop = fm.FontProperties(fname=font_path)
+    local_font_path = os.path.join(os.path.dirname(__file__), "assets", "fonts", "NanumGothic.ttf")
+    if os.path.exists(local_font_path):
+        prop = fm.FontProperties(fname=local_font_path)
         plt.rc("font", family=prop.get_name())
-        print(f"✅ 한글 폰트 적용됨: {prop.get_name()} ({font_path})")
+        plt.rcParams["axes.unicode_minus"] = False
+        print(f"✅ 로컬 NanumGothic 적용됨: {prop.get_name()}")
     else:
-        print("⚠️ 시스템에서 한글 폰트를 찾을 수 없습니다. 기본 설정을 사용합니다.")
+        print("❌ 로컬 폰트 파일 없음. 시스템 폰트 사용 시도")
 
-    plt.rcParams["axes.unicode_minus"] = False
 
 def run():
     setup_fonts()  # ✅ 여기에 호출 추가


### PR DESCRIPTION
feat: NanumGothic.ttf 로컬 폰트 포함 및 setup_fonts fallback 처리

- Streamlit Cloud 환경에서 한글 깨짐 현상 해결
- /assets/fonts/NanumGothic.ttf 직접 포함
- setup_fonts() 함수에 로컬 경로 fallback 로직 추가