### PR TITLE
🔧 Refactor: 실시간 투표 연동을 위해 Google Sheets 통합

### DIFF
--- a/pages/visual.py
+++ b/pages/visual.py
@@ -18,12 +18,20 @@ SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/YOUR_SPREADSHEET_ID/ed
 # ✅ 서비스 계정 인증
 @st.cache_resource
 def get_gsheet():
-    credentials = service_account.Credentials.from_service_account_file(
-        os.path.join(os.path.dirname(__file__), "..", "secrets", "google_service_account.json"),
-        scopes=SCOPE
-    )
-    client = gspread.authorize(credentials)
-    sheet = client.open_by_url(SPREADSHEET_URL).worksheet(SHEET_NAME)
+    import json
+
+    # 1. 비밀키를 secrets.toml에서 가져옴
+    json_str = st.secrets["GOOGLE_SERVICE_ACCOUNT"]
+    info = json.loads(json_str)
+
+    # 2. 자격증명 객체 생성
+    credentials = service_account.Credentials.from_service_account_info(info)
+    
+    # 3. gspread 클라이언트 초기화
+    gc = gspread.authorize(credentials)
+
+    # 4. 시트 접근
+    sheet = gc.open("google_vote_result").sheet1
     return sheet
 
 # ✅ 폰트 설정


### PR DESCRIPTION
- Google 서비스 계정을 활용하여 투표 결과를 Google Sheets에 저장 및 불러오기 구현
- `st.secrets` 기반 credentials 보안 설정 적용
- 로컬/배포 환경에 따라 NanumGothic 폰트 적용 로직 유지
- vote_result.csv → Google Sheets 실시간 반영 구조로 변경
- 사용자 타임스탬프 및 IP 정보 포함 저장

✅ 시트 이름: google_vote_result